### PR TITLE
Fix: Calling callback in sendToChannels

### DIFF
--- a/lib/push.js
+++ b/lib/push.js
@@ -46,6 +46,7 @@ Push.prototype.sendToChannels = function (channels, data, callback) {
   //Send to channels
   this.makeRequest(payload, "push", function(error, body){
     console.log(error, body);
+    if(callback) callback(error, body);
   });
 
 };


### PR DESCRIPTION
In Push.prototype.sendToChannels the callback wasn’t being called.