### PR TITLE
Proxy support

### DIFF
--- a/lib/push.js
+++ b/lib/push.js
@@ -26,7 +26,9 @@ function Push(options) {
 
   //Path
   this.path = options.path ? options.path : "/1/";
-
+  
+  //Proxy
+  this.proxy = options.proxy ? options.proxy : ""; 
 }
 
 /**
@@ -72,8 +74,13 @@ Push.prototype.makeRequest = function (jsonBody, endpoint, callback) {
     }
   };
   
+  var r = request;
+  
+  if (this.proxy.length > 0)
+    r = r.defaults({'proxy': this.proxy});
+
   //Make the request
-  request(options, function (error, response, body) {
+  r(options, function (error, response, body) {
     if (error) {
       callback(error);
     } else if (response.statusCode == 200) {


### PR DESCRIPTION
Usage

var push = new Push({
  applicationId: "MyApplicationId",
  restApiKey:    "MyRestApiKey",
  proxy: "http://myproxy:3128"
});