### PR TITLE
pass the body in the error

### DIFF
--- a/lib/push.js
+++ b/lib/push.js
@@ -79,7 +79,7 @@ Push.prototype.makeRequest = function (jsonBody, endpoint, callback) {
     } else if (response.statusCode == 200) {
       callback(undefined, body);
     } else {
-      callback(new Error("Error from Parse REST API"));
+      callback(new Error("Error from Parse REST API"), body);
     }
   });
 


### PR DESCRIPTION
body actually contains the error in body.error (depends on pull request #6)
